### PR TITLE
GitHub Pages 배포 자동화를 위한 GitHub Actions 워크플로우 생성

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Clean-install dependencies using Yarn
         run: |
           rm -rf node_modules
-          yarn install --frozne-lockfile
+          yarn install --frozen-lockfile
         working-directory: Web
 
       - name: Run script

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -1,0 +1,31 @@
+name: Build & deploy to GitHub Pages
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+jobs:
+  gh-pages-deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout `develop` branch
+        uses: actions/checkout@v2
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+      
+      - name: Clean-install dependencies using Yarn
+        run: |
+          rm -rf node_modules
+          yarn install --frozne-lockfile
+        working-directory: Web
+
+      - name: Run script
+        run: |
+          git config user.name "github-actions"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          yarn gh-pages-deploy
+        working-directory: Web

--- a/Web/scripts/gh-pages-deploy.js
+++ b/Web/scripts/gh-pages-deploy.js
@@ -4,13 +4,13 @@ const execa = require("execa");
   try {
     await execa("git", ["checkout", "--orphan", "gh-pages"]);
     console.log("Building...");
-    await execa("npm", ["run", "build"]);
+    await execa("yarn", ["build"]);
     await execa("git", ["--work-tree", "dist", "add", "--all"]);
     await execa("git", ["--work-tree", "dist", "commit", "-m", "gh-pages"]);
     console.log("Pushing to gh-pages...");
     await execa("git", ["push", "origin", "HEAD:gh-pages", "--force"]);
     await execa("rm", ["-r", "dist"]);
-    await execa("git", ["checkout", "-f", "master"]);
+    await execa("git", ["checkout", "-f", "develop"]);
     await execa("git", ["branch", "-D", "gh-pages"]);
     console.log("Successfully deployed");
   } catch(e) {


### PR DESCRIPTION
`develop` 브랜치에 커밋 발생 시 자동으로 빌드 및 GitHub Pages에 배포하는 GitHub Actions 워크플로우 셋업을 추가합니다.
이 워크플로우는 6af074b 에서 추가한 `gh-pages-deploy.js` 스크립트를 실행합니다.

워크플로우 적용 후 테스트가 필요합니다.