### PR TITLE
`class-methods-use-this` ESLint 규칙 무시

### DIFF
--- a/Web/.eslintrc.js
+++ b/Web/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
     "no-console": process.env.NODE_ENV === "production" ? "warn" : "off",
     "no-debugger": process.env.NODE_ENV === "production" ? "warn" : "off",
     "lines-between-class-members": "off",
+    "class-methods-use-this": "off",
     quotes: ["error", "double"],
-    "@typescript-eslint/no-var-requires": 0,
   },
 };

--- a/Web/scripts/gh-pages-deploy.js
+++ b/Web/scripts/gh-pages-deploy.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-extraneous-dependencies
 const execa = require("execa");
 
 (async () => {
@@ -13,7 +14,7 @@ const execa = require("execa");
     await execa("git", ["checkout", "-f", "master"]);
     await execa("git", ["branch", "-D", "gh-pages"]);
     console.log("Successfully deployed");
-  } catch(e) {
+  } catch (e) {
     console.log(e.message);
     process.exit(1);
   }

--- a/Web/vue.config.js
+++ b/Web/vue.config.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 module.exports = {
   publicPath: process.env.NODE_ENV === "production" ? "/AI_WEB_POOL_YD/" : "/",
   transpileDependencies: [

--- a/Web/vue.config.js
+++ b/Web/vue.config.js
@@ -1,5 +1,3 @@
-const path = require("path");
-
 module.exports = {
   publicPath: process.env.NODE_ENV === "production" ? "/AI_WEB_POOL_YD/" : "/",
   transpileDependencies: [


### PR DESCRIPTION
TS 클래스 스타일 Vue 컴포넌트 작성 시, 해당 ESLint 규칙을 따르게 되면 한정자(static) 때문에 일부 클래스 멤버를 정상적으로 사용할 수 없게 됩니다.
규칙 문서 : https://eslint.org/docs/rules/class-methods-use-this

예시로,
```typescript
export default class ExampleComponent extends Vue {
  get testGetter(): string {
    return "some data";
  }
}
```
는 정상적으로 작동(`<template>` 내에서 바인드하여 사용하여도 문제 없음)하는 컴포넌트 클래스 코드입니다.
하지만 해당 규칙은 `testGetter()` 메서드 내에서 자신의 부모 클래스를 참조하는 `this` 키워드가 사용되지 않았기 때문에 클래스 한정 멤버일 필요가 없다고 판단, static으로 작성할 것을 강제합니다.

규칙을 따라 수정한 코드(`testGetter()` 부분만),
```typescript
static get testGetter(): string {
  return "some data";
}
```
는 `<template>` 내에서 사용하려고 시도하는 경우 동작하지 않음을 확인했습니다.

이런 Vue의 특성으로 인해 해당 규칙을 무시하여야 한다는 결론을 냈습니다.