### PR TITLE
약간의 스타일링

### DIFF
--- a/Web/src/App.vue
+++ b/Web/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app>
-    <v-app-bar app color="primary" dark>
+    <v-app-bar app color="primary" dark dense>
       <v-toolbar-title>
         <router-link id="nav-title-text" :to="homeRouteUrl">{{ $store.state.appName }}</router-link>
       </v-toolbar-title>
@@ -29,7 +29,7 @@
     </v-main>
 
     <v-bottom-navigation v-if="$store.state.loginState.loggedIn" app class="d-sm-none">
-      <app-tab-navigation :tabGrow="true" />
+      <app-tab-navigation :mobileMode="true" />
     </v-bottom-navigation>
   </v-app>
 </template>

--- a/Web/src/App.vue
+++ b/Web/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
-    <v-app-bar app color="primary" dark dense>
-      <v-toolbar-title>
+    <v-app-bar app color="white" light dense :elevate-on-scroll="$route.meta.appBarElevateOnScroll ? true : false">
+      <v-toolbar-title class="primary--text" style="font-weight: 900">
         <router-link id="nav-title-text" :to="homeRouteUrl">{{ $store.state.appName }}</router-link>
       </v-toolbar-title>
 
@@ -100,13 +100,36 @@ export default class App extends Vue {
 </script>
 
 <style lang="scss">
-.v-app-bar > .v-toolbar__content {
-  margin: auto;
-  max-width: 800px;
-}
+.v-app-bar {
+  #nav-title-text {
+    position: relative;
 
-.v-app-bar .v-tabs {
-  width: auto !important;
+    &::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      right: 0;
+      height: 2px;
+      width: 100%;
+      bottom: 0;
+      background-color: currentColor;
+      transform: scaleX(0);
+      transition: transform 0.33s cubic-bezier(0, 0, 0, 1);
+    }
+
+    &:hover::after {
+      transform: scaleX(1);
+    }
+  }
+
+  & > .v-toolbar__content {
+    margin: auto;
+    max-width: 800px;
+  }
+
+  .v-tabs {
+    width: auto !important;
+  }
 }
 
 .v-bottom-navigation {

--- a/Web/src/components/app/AppTabNavigation.vue
+++ b/Web/src/components/app/AppTabNavigation.vue
@@ -2,12 +2,12 @@
   <v-tabs :left="tabsPosition == 'left'"
           :right="tabsPosition == 'right'"
           :centered="tabsPosition == 'center'"
-          :grow="tabGrow"
+          :grow="mobileMode ? true : false"
           optional
           icons-and-text>
-    <v-tab to="/feed">피드 <v-icon>mdi-card-text</v-icon></v-tab>
-    <v-tab to="/discover">탐색 <v-icon>mdi-compass</v-icon></v-tab>
-    <v-tab to="/pool">풀 <v-icon>mdi-approximately-equal-box</v-icon></v-tab>
+    <v-tab to="/feed">피드 <v-icon v-if="mobileMode">mdi-card-text</v-icon></v-tab>
+    <v-tab to="/discover">탐색 <v-icon v-if="mobileMode">mdi-compass</v-icon></v-tab>
+    <v-tab to="/pool">풀 <v-icon v-if="mobileMode">mdi-approximately-equal-box</v-icon></v-tab>
   </v-tabs>
 </template>
 
@@ -19,6 +19,6 @@ import { Prop } from "vue-property-decorator";
 @Component
 export default class AppTabNavigation extends Vue {
   @Prop({ default: "center" }) tabsPosition!: string;
-  @Prop({ default: false }) tabGrow!: boolean;
+  @Prop({ default: false }) mobileMode!: boolean;
 }
 </script>

--- a/Web/src/pages/feed/MainFeedPage.vue
+++ b/Web/src/pages/feed/MainFeedPage.vue
@@ -1,14 +1,16 @@
 <template>
-  <v-responsive class="mx-auto pa-2 px-sm-6" max-width="800px">
-    <feed-compose class="my-3" />
+  <v-container fluid class="feed-container">
+    <v-responsive class="mx-auto pa-2 px-sm-6" max-width="800px">
+      <feed-compose class="my-3" />
 
-    <v-divider class="my-8" />
+      <v-divider class="my-8" />
 
-    <feed-item v-for="item in feedItems"
-      class="my-3"
-      :key="item.index"
-      :itemData="item" />
-  </v-responsive>
+      <feed-item v-for="item in feedItems"
+        class="my-8"
+        :key="item.index"
+        :itemData="item" />
+    </v-responsive>
+  </v-container>
 </template>
 
 <script lang="ts">
@@ -97,3 +99,9 @@ export default class MainFeedPage extends Vue {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.feed-container {
+  background-color: #FAFBFB;
+}
+</style>

--- a/Web/src/router/index.ts
+++ b/Web/src/router/index.ts
@@ -40,6 +40,9 @@ const routes: Array<RouteConfig> = [
     path: "/me",
     name: "Account profile/information page",
     component: MyPage,
+    meta: {
+      appBarElevateOnScroll: true,
+    },
   },
 
   /* Article related routes */


### PR DESCRIPTION
- 네비바를 항상 얇게(dense) 설정합니다.
- 네비바의 배경색을 하얀색으로 설정합니다.
- 피드 페이지에 아주 약간의 그레이톤의 배경색을 추가합니다.
- 라우트의 `appBarElevateOnScroll` 메타값에 따라, 페이지 최상단에서의 네비바 그림자 표시 여부가 결정됩니다.
  > 여기서 `/me` 한번 들어가보셔요 꽤 이뻐요
- 네비바 제목(서비스명)의 색상을 primary로 설정하고, 마우스 hover 시 밑줄이 전환 효과와 함께 표시됩니다.