### PR TITLE
로그인 폼 ID 규칙 수정

### DIFF
--- a/Web/src/components/app/AppNonLoginAccountMenu.vue
+++ b/Web/src/components/app/AppNonLoginAccountMenu.vue
@@ -58,19 +58,7 @@ export default class AppNonLoginAccountMenu extends Vue {
   loginFormId = "";
   loginFormIdRules: Array<(value: string) => boolean | string> = [
     (value) => !!value || "ID를 입력해주세요.",
-    (value) => (value && /^[a-zA-Z.]+$/.test(value)) || "ID는 영문자 및 마침표(.)만 사용할 수 있습니다.",
-    (value) => (value && !/\.$/.test(value)) || "ID의 마지막 문자로 마침표(.)를 사용할 수 없습니다.",
-    (value) => {
-      const regExExec = /\.{2,}/.exec(value);
-
-      if (value && regExExec) {
-        if (regExExec.index > 0) {
-          return "마침표(.) 문자는 연속으로 입력할 수 없습니다.";
-        }
-      }
-
-      return true;
-    },
+    (value) => (value && /^[a-zA-Z0-9-.]+@[a-zA-Z0-9-]+\.[a-zA-Z]+(\.[a-zA-Z]+)?$/.test(value)) || "올바른 이메일 주소를 입력해주세요.",
   ];
   loginFormPassword = "";
   loginFormPasswordShow = false;


### PR DESCRIPTION
ID로 이메일 주소만 받기로 하여 이메일 주소 형식 규칙을 추가합니다.

이 외 규칙은 텍스트필드가 비어있을 때를 제외하고는 보안성을 위하여 전부 제거합니다.